### PR TITLE
fix: remove importlib-metadata pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-importlib-metadata==4.11.1
 pytest==7.0.1
 pytest-cov==3.0.0
 sentinel==0.3.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ if __name__ == "__main__":
                 "sentinel==0.3.0",
                 "sqlalchemy>=1.4",
                 "strawberry-graphql>=0.95",
-                "importlib-metadata==4.11.1",
             ],
         )
     except:  # noqa


### PR DESCRIPTION
## Summary
- Remove hardcoded `importlib-metadata==4.11.1` from `setup.py`
- Remove `importlib-metadata==4.11.1` from `requirements.txt`

The `setup.cfg` already has the correct conditional: `importlib-metadata; python_version<"3.8"`. The hardcoded pin in `setup.py` was overriding this and causing dependency conflicts with packages that require newer importlib-metadata versions (e.g., FastMCP requires `>=6.0`).